### PR TITLE
Fix Profiler so it works when reports dir does not exist yet

### DIFF
--- a/anp_sales_miner/helpers/profiler.py
+++ b/anp_sales_miner/helpers/profiler.py
@@ -1,7 +1,15 @@
+import os
+from pathlib import Path
+
 import pandas as pd
 from pandas_profiling import ProfileReport
 
 from anp_sales_miner.helpers.io_helper import make_path
+
+
+def _make_output_path(base_dir='reports', filename='anp_fuel_sales.html'):
+    Path(base_dir).mkdir(parents=False, exist_ok=True)
+    return os.sep.join([base_dir, filename])
 
 
 def profile_table():
@@ -12,4 +20,4 @@ def profile_table():
     transformed_df['year_month'] = transformed_df['year_month'].astype(str).astype('datetime64[M]')
 
     profile = ProfileReport(transformed_df, title='ANP Fuel Sales Profiling Report')
-    profile.to_file('reports/anp_fuel_sales.html')
+    profile.to_file(_make_output_path())


### PR DESCRIPTION
> **Note**: Please check if the **PR** fulfills the requirements below

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Fix

## What is the current behavior? (You can also link to an open issue here)
`Profiler` won't work if it is being run for the first time. This is because it won't find dir `reports`, where it saves the HTML report.

## What is the new behavior (if this is a feature change)?
`Profiler` will work with or without the `reports` dir already existing.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No, it fixes one.

## Other information
This line is already covered by tests. But, ideally, we should extend the test suite to test this exact scenario (where `reports` dir does not exist yet).
