### PR TITLE
Update Actions workflow to include coverage badge

### DIFF
--- a/.github/coverage_badge_creator.sh
+++ b/.github/coverage_badge_creator.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+coverage_perc="$(pipenv run coverage json -o /dev/stdout | jq '.totals.percent_covered_display | tonumber')"
+
+if [ "$coverage_perc" -ge 85 ]; then
+  color="green"
+elif [ "$coverage_perc" -ge 65 ]; then
+  color="yellow"
+else
+  color="red"
+fi
+
+curl "https://img.shields.io/badge/coverage-$coverage_perc%25-$color" -o coverage_badge.svg --no-progress-meter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install system dependencies
-        run: sudo apt-get install python3-distutils python3 curl -y
+        run: sudo apt-get install jq python3-distutils python3 curl -y
       - name: Install pip
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
       - name: Install pip dependencies
@@ -21,7 +21,38 @@ jobs:
       - name: Move tests fixtures
         run: sudo mkdir -p /var/anp_sales_miner/tests; sudo mv -t /var/anp_sales_miner/tests tests/fixtures
       - name: Run tests
-        run: pipenv run python -m pytest
+        run: pipenv run python -m pytest --cov=anp_sales_miner tests/ --cov-report term-missing
+      - name: Create coverage badge
+        run: bash .github/coverage_badge_creator.sh
+      - name: Archive code coverage badge
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-badge
+          path: coverage_badge.svg
+          retention-days: 1
+
+  update-coverage-badge:
+    # Inspired by https://hackernoon.com/adding-test-coverage-badge-on-github-without-using-third-party-services
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Download code coverage badge
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-badge
+          path: badges
+      - name: Deploy badge to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: badges
+          token: ${{ secrets.GH_DEPLOY_BADGE_TOKEN }}
+          branch: main
+          repository-name: pmhaddad/pmhaddad.github.io
+          target-folder: badges
 
   deploy:
     needs: test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ANP Sales Miner
 
+![coverage](https://pmhaddad.github.io/badges/coverage_badge.svg?raw=true)
 [![test and deploy](https://github.com/pmhaddad/anp_sales_miner/actions/workflows/test.yml/badge.svg)](https://github.com/pmhaddad/anp_sales_miner/actions/workflows/test.yml)
 
 This project is aimed to solve the **Data Engineering Test** [available here](https://github.com/raizen-analytics/data-engineering-test)


### PR DESCRIPTION
> **Note**: Please check if the **PR** fulfills the requirements below

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature

## What is the current behavior? (You can also link to an open issue here)
Project's README does not contain a coverage badge

## What is the new behavior (if this is a feature change)?
Every time a **PR** is merged on `main`, a coverage badge will be deployed into the interwebs and become available for display into the README file

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No, it should not.

## Other information
At the time of this **PR**, this repo is private. So I can't use branch `gh-pages` to store the badge within this repo itself. If it goes public, we can change that 👍 
