### PR TITLE
Make sure build ignore pip cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV LC_ALL=C.UTF-8
 
 ENV TZ=UTC
 
+ARG PIP_NO_CACHE_DIR=1
+
 RUN apt-get update -y
 
 RUN apt-get install python3-distutils python3 curl -y


### PR DESCRIPTION
> **Note**: Please check if the **PR** fulfills the requirements below

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Fix

## What is the current behavior? (You can also link to an open issue here)
Container build may fail if there are conflicts between a local pip cache, and this project's `Pipfile`

## What is the new behavior (if this is a feature change)?
Image build will ignore `pip`'s cache

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
It should not.

## Other information
