### PR TITLE
Make sure Pipfile.lock is used during deploys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pip
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
       - name: Install pip dependencies
-        run: pipenv install --dev
+        run: pipenv verify && pipenv sync --dev
       - name: Run flake8
         run: pipenv run flake8
       - name: Move tests fixtures

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /var/anp_sales_miner
 
 COPY . .
 
-RUN pipenv install --dev
+RUN pipenv verify && pipenv sync --dev
 
 EXPOSE 8080
 


### PR DESCRIPTION
> **Note**: Please check if the **PR** fulfills the requirements below

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Update (and sort of a fix)

## What is the current behavior? (You can also link to an open issue here)
We use `pipenv install` on all deploys and builds (GitHub Actions and Docker). This is problematic, because `install` will not honor `Pipfile.lock` (it honors only `Pipfile`). So the same environment is not properly guaranteed.

## What is the new behavior (if this is a feature change)?
We use `pipenv sync`, which uses dependencies versions as in `Pipfile.lock`. We also add a `pipenv verify` first, to make sure the lock is up-to-date.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No, it does not. It kind of fixes one

## Other information
