### PR TITLE
Group version updates for Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,19 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  groups:
+    python-prod-dependencies:
+      dependency-type: "production"
+      applies-to: version-updates
+      update-types:
+      - "minor"
+      - "patch"
+    python-dev-dependencies:
+      dependency-type: "development"
+      applies-to: version-updates
+      update-types:
+      - "minor"
+      - "patch"
 - package-ecosystem: "docker"
   directory: "/"
   schedule:


### PR DESCRIPTION
> **Note**: Please check if the **PR** fulfills the requirements below

- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature

## What is the current behavior? (You can also link to an open issue here)
For each version update dependabot finds, a new **PR** is opened. This is creating the need for multiple rebases, as each **PR** is merged into `main`, and the remaining **PRs** get outdated.

## What is the new behavior (if this is a feature change)?
We use the [`groups` feature](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) from dependabot, in the hopes it will reduce the number of **PRs**, merges and rebases.

To keep some level of separation, we split dev and prod dependencies, and only group minor and patch releases!

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
It should not, but could be.

## Other information
